### PR TITLE
bugfix/Two scrollbars on my skill profile page

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -13,11 +13,11 @@
 }
 
 .sidenavContainer--mobile {
-  margin-top: 56px;
+  padding-top: 56px;
 }
 
 .sidenavContainer--desktop {
-  margin-top: 64px;
+  padding-top: 64px;
 }
 
 .sidenavContainer__drawer {
@@ -25,11 +25,11 @@
 }
 
 .sidenavContainer__drawer--mobile {
-  margin-top: 56px;
+  padding-top: 56px;
 }
 
 .sidenavContainer__drawer--desktop {
-  margin-top: 64px;
+  padding-top: 64px;
 }
 
 .sidenavContainer__content {


### PR DESCRIPTION
Margin to shift sidenavContainer down on height of a toolbar replaced with padding.
Thus the shift can be on the page all the time despite on position of a vertical scrollbar.
@svetivanova please take a look.