### PR TITLE
feature/integration-of-test-coverage-report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ cache:
 
 install:
   - npm install
+  - npm install codecov
 
 script:
-  - npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI
+  - npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI --code-coverage
+  - codecov
   #- npm run e2e -- --protractor-config=./e2e/protractor-ci.conf.js

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@ Georg Wittberger <georg.wittberger@gmail.com>
 v0.0.1, 2018-12-23
 
 image:https://travis-ci.org/KnowledgeAssets/myskills-webapp.svg?branch=master["Build Status", link="https://travis-ci.org/KnowledgeAssets/myskills-webapp"]
+image:https://codecov.io/gh/KnowledgeAssets/myskills-webapp/branch/master/graph/badge.svg["Code Coverage", link="https://codecov.io/gh/KnowledgeAssets/myskills-webapp"]
 image:https://img.shields.io/github/issues-raw/KnowledgeAssets/myskills-webapp.svg["GitHub issues",link="https://github.com/KnowledgeAssets/myskills-webapp/issues"]
 image:https://img.shields.io/github/license/KnowledgeAssets/myskills-webapp.svg["MIT License"]
 
@@ -145,6 +146,8 @@ The automated tests can be executed by running the following command in the proj
     npm test
 
 _Note: The Karma configuration relies on Chrome as the browser to run the tests._
+
+Travis CI uploads test coverage reports to https://codecov.io[codecov.io]. Uploaded reports can be found https://codecov.io/gh/KnowledgeAssets/myskills-webapp[here].
 
 === Architecture overview
 


### PR DESCRIPTION
Code coverage report is generated and uploaded to codecov.io.
@svetivanova please take a look.