### PR TITLE
feature/provide-outbound-and-inbound-user-permissions

### DIFF
--- a/src/app/users/users.service.spec.ts
+++ b/src/app/users/users.service.spec.ts
@@ -193,7 +193,7 @@ describe('UsersService', () => {
 
     const request = httpTestingController.expectOne({
       method: 'GET',
-      url: `${environment.serverApiUrl}/users/${authenticatedUser.userId}/permissions`
+      url: `${environment.serverApiUrl}/users/${authenticatedUser.userId}/outbound-permissions`
     });
 
     expect(request.request.responseType).toEqual('json');

--- a/src/app/users/users.service.ts
+++ b/src/app/users/users.service.ts
@@ -14,7 +14,7 @@ import { UserRequest } from './user-request';
 })
 export class UsersService {
   private userUrlPattern = `${environment.serverApiUrl}/users/{userId}`;
-  private userPermissionsUrlPattern = `${environment.serverApiUrl}/users/{userId}/permissions`;
+  private userPermissionsUrlPattern = `${environment.serverApiUrl}/users/{userId}/outbound-permissions`;
   private userSuggestionsUrl = `${environment.serverApiUrl}/user-suggestions`;
 
   constructor(private httpClient: HttpClient,


### PR DESCRIPTION
Paths to endpoints working with outbound user permissions were changed from /permissions to /outbound-permissions.
@svetivanova could you please take a look?