### PR TITLE
show info dialog after successfully sending a join request to a closed community

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -52,6 +52,7 @@ import { CommunityViewComponent } from './community-view/community-view.componen
 import { SearchUserFormComponent } from './search-users/search-user-form/search-user-form.component';
 import { SearchUserResultsComponent } from './search-users/search-user-results/search-user-results.component';
 import { FormatCounterPipe } from './format-counter.pipe';
+import { ClosedCommunityInfoDialogComponent } from './shared/closed-community-info-dialog/closed-community-info-dialog.component';
 
 export const CUSTOM_FORMATS = {
   parse: {
@@ -98,6 +99,7 @@ export const CUSTOM_FORMATS = {
     SearchUserFormComponent,
     SearchUserResultsComponent,
     FormatCounterPipe,
+    ClosedCommunityInfoDialogComponent,
   ],
   imports: [
     BrowserModule,
@@ -140,7 +142,8 @@ export const CUSTOM_FORMATS = {
     MyProjectsEditComponent,
     CommunitiesNewComponent,
     CommunitiesEditComponent,
-    ClosedCommunityConfirmDialogComponent
+    ClosedCommunityConfirmDialogComponent,
+    ClosedCommunityInfoDialogComponent
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/communities/communities.component.spec.ts
+++ b/src/app/communities/communities.component.spec.ts
@@ -166,7 +166,7 @@ describe('CommunitiesComponent', () => {
     expect(component.isCommunityJoined({id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'} as CommunityResponse)).toBeTruthy();
   }));
 
-  it('should not make user join a closed community', fakeAsync(() => {
+  it('should not make user join a closed community and display closed community info dialog', fakeAsync(() => {
     const closedCommunity = {
       id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
       title: 'test1',

--- a/src/app/communities/communities.component.ts
+++ b/src/app/communities/communities.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { CommunitiesService } from './communities.service';
 import { combineLatest, Observable, of } from 'rxjs';
-import { filter} from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { GlobalErrorHandlerService } from '../error/global-error-handler.service';
 import { MatBottomSheet, MatDialog } from '@angular/material';
@@ -14,6 +14,7 @@ import { CommunityResponse } from './community-response';
 import { User } from '../users/user';
 import { UserIdentityService } from '../shared/user-identity.service';
 import { Community } from './community';
+import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
 
 @Component({
   selector: 'app-communities',
@@ -65,8 +66,12 @@ export class CommunitiesComponent implements OnInit {
   }
 
   joinCommunity(community: CommunityResponse) {
-    this.communityService.joinCommunity(community.id).subscribe((response: CommunityResponse) => {
-      this.joinedCommunityIds.push(response.id);
+    this.communityService.joinCommunity(community.id).subscribe((community: CommunityResponse) => {
+      if (community.type === CommunityType.CLOSED) {
+        this.showInfoDialog(community);
+      } else {
+        this.joinedCommunityIds.push(community.id);
+      }
     }, (errorResponse: HttpErrorResponse) => {
       this.handleErrorResponse(errorResponse);
     });
@@ -135,4 +140,19 @@ export class CommunitiesComponent implements OnInit {
     this.changeDetector.markForCheck();
   }
 
+  private showInfoDialog(community: CommunityResponse) {
+    this.dialog.open(ClosedCommunityInfoDialogComponent, {
+      width: '350px',
+      data: <CommunityResponse>{
+        id: community.id,
+        title: community.title,
+        type: community.type,
+        skills: community.skills,
+        description: community.description,
+        links: community.links,
+        managers: community.managers,
+        members: community.members
+      }
+    });
+  }
 }

--- a/src/app/communities/communities.component.ts
+++ b/src/app/communities/communities.component.ts
@@ -143,16 +143,7 @@ export class CommunitiesComponent implements OnInit {
   private showInfoDialog(community: CommunityResponse) {
     this.dialog.open(ClosedCommunityInfoDialogComponent, {
       width: '350px',
-      data: <CommunityResponse>{
-        id: community.id,
-        title: community.title,
-        type: community.type,
-        skills: community.skills,
-        description: community.description,
-        links: community.links,
-        managers: community.managers,
-        members: community.members
-      }
+      data: Object.assign({}, community)
     });
   }
 }

--- a/src/app/community-view/community-view.component.spec.ts
+++ b/src/app/community-view/community-view.component.spec.ts
@@ -191,7 +191,7 @@ describe('CommunityViewComponent', () => {
     expect(component.isCommunityMember).toBeFalsy();
   }));
 
-  it('should not make user join a closed community', fakeAsync(() => {
+  it('should not make user join a closed community and display closed community info dialog', fakeAsync(() => {
     const closedCommunity = {
       id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
       title: 'test1',

--- a/src/app/community-view/community-view.component.ts
+++ b/src/app/community-view/community-view.component.ts
@@ -9,6 +9,8 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { DeleteConfirmationDialogComponent } from '../shared/delete-confirmation-dialog/delete-confirmation-dialog.component';
 import { MatDialog } from '@angular/material';
 import { User } from '../users/user';
+import { CommunityType } from '../communities/community-type.enum';
+import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
 
 @Component({
   selector: 'app-community-view',
@@ -42,8 +44,12 @@ export class CommunityViewComponent implements OnInit {
 
   joinCommunity() {
     this.communityService.joinCommunity(this.community.id).subscribe((community: CommunityResponse) => {
-      this.isCommunityMember = true;
-      this.community = community;
+      if (community.type === CommunityType.CLOSED) {
+        this.showInfoDialog(community);
+      } else {
+        this.isCommunityMember = true;
+        this.community = community;
+      }
     }, (errorResponse: HttpErrorResponse) => {
       this.handleErrorResponse(errorResponse);
     });
@@ -122,5 +128,21 @@ export class CommunityViewComponent implements OnInit {
     this.errorMessage = this.globalErrorHandlerService.createFullMessage(errorResponse);
     // Dirty fix because of: https://github.com/angular/angular/issues/17772
     this.changeDetector.markForCheck();
+  }
+
+  private showInfoDialog(community: CommunityResponse) {
+    this.dialog.open(ClosedCommunityInfoDialogComponent, {
+      width: '350px',
+      data: <CommunityResponse>{
+        id: community.id,
+        title: community.title,
+        type: community.type,
+        skills: community.skills,
+        description: community.description,
+        links: community.links,
+        managers: community.managers,
+        members: community.members
+      }
+    });
   }
 }

--- a/src/app/community-view/community-view.component.ts
+++ b/src/app/community-view/community-view.component.ts
@@ -133,16 +133,7 @@ export class CommunityViewComponent implements OnInit {
   private showInfoDialog(community: CommunityResponse) {
     this.dialog.open(ClosedCommunityInfoDialogComponent, {
       width: '350px',
-      data: <CommunityResponse>{
-        id: community.id,
-        title: community.title,
-        type: community.type,
-        skills: community.skills,
-        description: community.description,
-        links: community.links,
-        managers: community.managers,
-        members: community.members
-      }
+      data: Object.assign({}, community)
     });
   }
 }

--- a/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.html
+++ b/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.html
@@ -1,0 +1,10 @@
+<div fxLayout="row" >
+  <div fxFlex fxLayoutAlign="center center" mat-dialog-content>
+    <p>The join request has been successfully sent to the community "{{community.title}}".</p>
+  </div>
+</div>
+<div fxLayout="row">
+  <div fxFlex fxLayoutAlign="center center" mat-dialog-actions>
+    <button mat-button (click)="dialogRef.close()" cdkFocusInitial>OK</button>
+  </div>
+</div>

--- a/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.spec.ts
+++ b/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.spec.ts
@@ -1,0 +1,47 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClosedCommunityInfoDialogComponent } from './closed-community-info-dialog.component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { CommunityType } from '../../communities/community-type.enum';
+
+const communityData = {
+  id: '2134-5679-235235',
+  title: 'community',
+  description: 'community description',
+  type: CommunityType.OPENED,
+  skills: [],
+  links: [
+    {
+      name: 'google',
+      href: 'https://www.google.com'
+    }
+  ],
+  managers: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}],
+  members: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}]
+};
+
+describe('ClosedCommunityInfoDialogComponent', () => {
+  let component: ClosedCommunityInfoDialogComponent;
+  let fixture: ComponentFixture<ClosedCommunityInfoDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ClosedCommunityInfoDialogComponent ],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: communityData }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClosedCommunityInfoDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.ts
+++ b/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.ts
@@ -1,0 +1,18 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { CommunityResponse } from '../../communities/community-response';
+
+@Component({
+  selector: 'app-closed-community-info-dialog',
+  templateUrl: './closed-community-info-dialog.component.html',
+  styleUrls: ['./closed-community-info-dialog.component.scss']
+})
+export class ClosedCommunityInfoDialogComponent implements OnInit {
+
+  constructor(public dialogRef: MatDialogRef<ClosedCommunityInfoDialogComponent>,
+              @Inject(MAT_DIALOG_DATA) public community: CommunityResponse) { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
displaying an info dialog instead of error message when joining to a closed community.
@LebedkoDmitry could you please take a look?