### PR TITLE
feature/rework-of-communities-api

### DIFF
--- a/src/app/communities/communities-edit.component.html
+++ b/src/app/communities/communities-edit.component.html
@@ -9,7 +9,7 @@
     <div fxFlex>
       <span>Community type:</span>
       <mat-button-toggle-group formControlName="type" class="communities-edit-type">
-        <mat-button-toggle value="OPENED" class="communities-edit-type-option">Opened</mat-button-toggle>
+        <mat-button-toggle value="OPEN" class="communities-edit-type-option">Open</mat-button-toggle>
         <mat-button-toggle value="CLOSED" class="communities-edit-type-option">Closed</mat-button-toggle>
       </mat-button-toggle-group>
     </div>

--- a/src/app/communities/communities-edit.component.spec.ts
+++ b/src/app/communities/communities-edit.component.spec.ts
@@ -27,7 +27,7 @@ const communityEditData = {
   id: '2134-5679-235235',
   title: 'community',
   description: 'community description',
-  type: CommunityType.OPENED,
+  type: CommunityType.OPEN,
   skills: [],
   links: [
     {
@@ -35,9 +35,8 @@ const communityEditData = {
       href: 'https://www.google.com'
     }
   ],
-  managers: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}],
-  members: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}]
-};
+  managers: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}]
+} as CommunityResponse;
 
 const communityEditRequest = {
   id: communityEditData.id,

--- a/src/app/communities/communities-edit.component.ts
+++ b/src/app/communities/communities-edit.component.ts
@@ -95,7 +95,7 @@ export class CommunitiesEditComponent implements OnInit {
 
   editCommunity() {
     const communityData = this.getCommunityData();
-    if (communityData.type === CommunityType.OPENED || communityData.type === this.community.type) {
+    if (communityData.type === CommunityType.OPEN || communityData.type === this.community.type) {
       this.innerEditCommunity(communityData);
     } else {
       const dialogRef = this.dialog.open(ClosedCommunityConfirmDialogComponent, {

--- a/src/app/communities/communities-filter.pipe.spec.ts
+++ b/src/app/communities/communities-filter.pipe.spec.ts
@@ -7,7 +7,7 @@ const communities: CommunityResponse[] = [
     id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
     title: 'test1',
     description: 'description1',
-    type: CommunityType.OPENED,
+    type: CommunityType.OPEN,
     links: [{
       name: 'google',
       href: 'https://www.google.com'
@@ -16,20 +16,18 @@ const communities: CommunityResponse[] = [
         name: 'stackoveflow',
         href: 'https://stackoverflow.com/'
       }],
-    managers: [],
-    members: []
+    managers: []
   },
   {
     id: '6b7ebd19-4542-4c1d-9602-905e35b7f7f8',
     title: 'test2',
     description: 'description2',
-    type: CommunityType.OPENED,
+    type: CommunityType.OPEN,
     skills: [{
       id: '12343534536',
       name: 'java'
     }],
-    managers: [],
-    members: []
+    managers: []
   }
 ];
 

--- a/src/app/communities/communities-new.component.html
+++ b/src/app/communities/communities-new.component.html
@@ -9,7 +9,7 @@
     <div fxFlex>
       <span>Community type:</span>
       <mat-button-toggle-group formControlName="type" class="communities-new-type">
-        <mat-button-toggle value="OPENED" class="communities-new-type-option">Opened</mat-button-toggle>
+        <mat-button-toggle value="OPEN" class="communities-new-type-option">Open</mat-button-toggle>
         <mat-button-toggle value="CLOSED" class="communities-new-type-option">Closed</mat-button-toggle>
       </mat-button-toggle-group>
     </div>

--- a/src/app/communities/communities-new.component.spec.ts
+++ b/src/app/communities/communities-new.component.spec.ts
@@ -122,7 +122,7 @@ describe('CommunitiesNewComponent', () => {
       const expectedRequestData: CommunityRequest = {
         title: 'title',
         description: 'description',
-        type: CommunityType.OPENED,
+        type: CommunityType.OPEN,
         skillNames: [],
         links: [
           {

--- a/src/app/communities/communities-new.component.ts
+++ b/src/app/communities/communities-new.component.ts
@@ -63,7 +63,7 @@ export class CommunitiesNewComponent implements OnInit {
     this.loadUsers();
     this.communityForm = this.formBuilder.group({
       title: new FormControl('', Validators.required),
-      type: new FormControl(CommunityType.OPENED),
+      type: new FormControl(CommunityType.OPEN),
       skills: new FormControl([]),
       description: new FormControl(''),
       links: new FormArray([]),
@@ -81,7 +81,7 @@ export class CommunitiesNewComponent implements OnInit {
 
   createCommunity() {
     const communityData = this.getCommunityData();
-    if (communityData.type === CommunityType.OPENED) {
+    if (communityData.type === CommunityType.OPEN) {
       this.innerCreateCommunity(communityData);
     } else {
       const dialogRef = this.dialog.open(ClosedCommunityConfirmDialogComponent, {

--- a/src/app/communities/communities.component.spec.ts
+++ b/src/app/communities/communities.component.spec.ts
@@ -101,7 +101,19 @@ describe('CommunitiesComponent', () => {
         {
           provide: CommunitiesService, useValue: jasmine.createSpyObj('communityService', {
             'getCommunities': of<Community[]>(communities),
-            'getUserCommunities': of<CommunityUserResponse[]>(),
+            'getUserCommunities': of<CommunityResponse[]>(
+              [
+                {
+                  id: '123',
+                  title: 'Java User Group',
+                  type: CommunityType.OPEN
+                } as CommunityResponse,
+                {
+                  id: '456',
+                  title: 'Scala User Group'
+                } as CommunityResponse
+              ]
+            ),
             'deleteCommunity': of<void>(),
             'joinCommunity': of<CommunityResponse>({
               id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',

--- a/src/app/communities/communities.component.spec.ts
+++ b/src/app/communities/communities.component.spec.ts
@@ -20,6 +20,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
 import { MatDialog } from '@angular/material';
+import { CommunityUserResponse } from './community-user-response';
+import { CommunityRole } from './community-role.enum';
 import { CommunityCardComponent } from '../shared/community-card/community-card.component';
 import { Component } from '@angular/core';
 
@@ -28,7 +30,7 @@ const communities: CommunityResponse[] = [
     id: '123',
     title: 'group1',
     description: 'super group description',
-    type: CommunityType.OPENED,
+    type: CommunityType.OPEN,
     recommended: true,
     links: [
       {
@@ -39,12 +41,6 @@ const communities: CommunityResponse[] = [
         name: 'stackoveflow',
         href: 'https://stackoverflow.com/'
       }],
-    members: [
-      {
-        id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759',
-        userName: 'tester'
-      } as User
-    ],
     managers: [
       {
         id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759',
@@ -56,13 +52,7 @@ const communities: CommunityResponse[] = [
     id: '123456',
     title: 'group2',
     description: 'other group',
-    type: CommunityType.OPENED,
-    members: [
-      {
-        id: 'c6d8badc-0f80-4d20-b436-0e7e871f97f5',
-        userName: 'anotherTester'
-      } as User
-    ],
+    type: CommunityType.OPEN,
     managers: [
       {
         id: 'c6d8badc-0f80-4d20-b436-0e7e871f97f5',
@@ -111,11 +101,12 @@ describe('CommunitiesComponent', () => {
         {
           provide: CommunitiesService, useValue: jasmine.createSpyObj('communityService', {
             'getCommunities': of<Community[]>(communities),
+            'getUserCommunities': of<CommunityUserResponse[]>(),
             'deleteCommunity': of<void>(),
             'joinCommunity': of<CommunityResponse>({
               id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
               title: 'test1',
-              type: CommunityType.OPENED,
+              type: CommunityType.OPEN,
               description: 'description1',
               links: [{
                 name: 'google',
@@ -125,8 +116,7 @@ describe('CommunitiesComponent', () => {
                   name: 'stackoveflow',
                   href: 'https://stackoverflow.com/'
                 }],
-              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-              members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
+              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
             } as CommunityResponse)
           })
         },
@@ -172,26 +162,18 @@ describe('CommunitiesComponent', () => {
   }));
 
   it('should not make user join a closed community and display closed community info dialog', fakeAsync(() => {
-    const closedCommunity = {
-      id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
-      title: 'test1',
-      type: CommunityType.CLOSED,
-      description: 'description1',
-      links: [{
-        name: 'google',
-        href: 'https://www.google.com'
-      },
-        {
-          name: 'stackoveflow',
-          href: 'https://stackoverflow.com/'
-        }],
-      managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-      members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
-    };
-    const communityService = TestBed.get(CommunitiesService) as CommunitiesService;
-    communityService.joinCommunity = jasmine.createSpy().and.returnValue(of(closedCommunity));
+    const response = {
+      role: CommunityRole.MEMBER,
+      user: {
+        id: authenticatedUser.userId,
+        userName: authenticatedUser.userName
+      } as User
+    } as CommunityUserResponse;
 
-    component.joinCommunity({id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'} as CommunityResponse);
+    const communityService = TestBed.get(CommunitiesService) as CommunitiesService;
+    communityService.joinCommunity = jasmine.createSpy().and.returnValue(of(response));
+
+    component.joinCommunity({id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f', type: CommunityType.CLOSED} as CommunityResponse);
     fixture.detectChanges();
     expect(component.isCommunityJoined({id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'} as CommunityResponse)).toBeFalsy();
 

--- a/src/app/communities/communities.component.ts
+++ b/src/app/communities/communities.component.ts
@@ -15,6 +15,7 @@ import { User } from '../users/user';
 import { UserIdentityService } from '../shared/user-identity.service';
 import { Community } from './community';
 import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
+import { CommunityUserResponse } from './community-user-response';
 
 @Component({
   selector: 'app-communities',
@@ -39,6 +40,7 @@ export class CommunitiesComponent implements OnInit {
 
   ngOnInit() {
     this.loadCommunities();
+    this.loadUserCommunities();
   }
 
   openNewDialog(): void {
@@ -55,18 +57,17 @@ export class CommunitiesComponent implements OnInit {
       data: <CommunityResponse>{
         id: community.id,
         title: community.title,
-        type: community.type || CommunityType.OPENED,
+        type: community.type || CommunityType.OPEN,
         skills: community.skills,
         description: community.description,
         links: community.links,
-        managers: community.managers,
-        members: community.members
+        managers: community.managers
       }
     }).afterDismissed().pipe(filter(Boolean)).subscribe(() => this.loadCommunities());
   }
 
   joinCommunity(community: CommunityResponse) {
-    this.communityService.joinCommunity(community.id).subscribe((community: CommunityResponse) => {
+    this.communityService.joinCommunity(community.id).subscribe((communityUserResponse: CommunityUserResponse) => {
       if (community.type === CommunityType.CLOSED) {
         this.showInfoDialog(community);
       } else {
@@ -94,6 +95,16 @@ export class CommunitiesComponent implements OnInit {
     });
   }
 
+  private loadUserCommunities(): void {
+    this.communityService.getUserCommunities().subscribe((userCommunities: CommunityResponse[]) => {
+      const joinedCommunityIds: string[] = [];
+      userCommunities.forEach(community => joinedCommunityIds.push(community.id));
+      this.joinedCommunityIds = joinedCommunityIds;
+    }, (errorResponse: HttpErrorResponse) => {
+      this.handleErrorResponse(errorResponse);
+    });
+  }
+
   private loadCommunities() {
     combineLatest(
       this.userIdentityService.getUserIdentity(),
@@ -103,23 +114,15 @@ export class CommunitiesComponent implements OnInit {
       const communities = compoundObject[1];
 
       this.communities$ = of(communities);
-      const joinedCommunityIds: string[] = [];
       const managedCommunityIds: string[] = [];
 
       communities.forEach((community: CommunityResponse) => {
-        if (community.members) {
-          if (community.members.map((member: User) => member.id).indexOf(userIdentity.userId) !== -1) {
-            joinedCommunityIds.push(community.id);
-          }
-        }
         if (community.managers) {
           if (community.managers.map((manager: User) => manager.id).indexOf(userIdentity.userId) !== -1) {
             managedCommunityIds.push(community.id);
           }
         }
       });
-
-      this.joinedCommunityIds = joinedCommunityIds;
       this.managedCommunityIds = managedCommunityIds;
     }, (errorResponse: HttpErrorResponse) => {
       this.handleErrorResponse(errorResponse);

--- a/src/app/communities/communities.service.spec.ts
+++ b/src/app/communities/communities.service.spec.ts
@@ -315,4 +315,28 @@ describe('CommunitiesService', () => {
     expect(req.request.method).toBe('DELETE');
   }));
 
+  it('should fetch user communities', async(() => {
+    const communities: CommunityResponse[] = [
+      {
+        id: '123',
+        title: 'Java User Group',
+        type: CommunityType.OPEN
+      } as CommunityResponse,
+      {
+        id: '456',
+        title: 'Scala User Group'
+      } as CommunityResponse
+    ];
+
+    service.getUserCommunities().subscribe((response) => {
+      expect(response).toBe(communities);
+    });
+
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `${environment.serverApiUrl}/users/${authenticatedUser.userId}/communities`
+    });
+    expect(req.request.method).toBe('GET');
+  }));
+
 });

--- a/src/app/communities/communities.service.spec.ts
+++ b/src/app/communities/communities.service.spec.ts
@@ -10,6 +10,9 @@ import { UserIdentity } from '../shared/user-identity';
 import { UserIdentityService } from '../shared/user-identity.service';
 import { of } from 'rxjs';
 import { CommunityUserRequest } from './community-user-request';
+import { CommunityUserResponse } from './community-user-response';
+import { CommunityRole } from './community-role.enum';
+import { User } from '../users/user';
 
 describe('CommunitiesService', () => {
   let httpTestingController: HttpTestingController;
@@ -43,8 +46,8 @@ describe('CommunitiesService', () => {
   });
 
   it('should be created', () => {
-    const service: CommunitiesService = TestBed.get(CommunitiesService);
-    expect(service).toBeTruthy();
+    const communitiesService: CommunitiesService = TestBed.get(CommunitiesService);
+    expect(communitiesService).toBeTruthy();
   });
 
   it('should provide list of communities', async(() => {
@@ -54,7 +57,7 @@ describe('CommunitiesService', () => {
         title: 'test1',
         skills: [],
         description: 'description1',
-        type: CommunityType.OPENED,
+        type: CommunityType.OPEN,
         links: [{
           name: 'google',
           href: 'https://www.google.com'
@@ -63,17 +66,15 @@ describe('CommunitiesService', () => {
             name: 'stackoveflow',
             href: 'https://stackoverflow.com/'
           }],
-        managers: [],
-        members: []
+        managers: []
       },
       {
         id: '6b7ebd19-4542-4c1d-9602-905e35b7f7f8',
         title: 'test2',
         skills: [],
         description: 'description2',
-        type: CommunityType.OPENED,
-        managers: [],
-        members: []
+        type: CommunityType.OPEN,
+        managers: []
       }
     ];
 
@@ -98,7 +99,7 @@ describe('CommunitiesService', () => {
         title: 'test1',
         skills: [],
         description: 'description1',
-        type: CommunityType.OPENED,
+        type: CommunityType.OPEN,
         links: [{
           name: 'google',
           href: 'https://www.google.com'
@@ -107,17 +108,15 @@ describe('CommunitiesService', () => {
             name: 'stackoveflow',
             href: 'https://stackoverflow.com/'
           }],
-        managers: [],
-        members: []
+        managers: []
       },
       {
         id: '6b7ebd19-4542-4c1d-9602-905e35b7f7f8',
         title: 'test2',
         skills: [],
         description: 'description2',
-        type: CommunityType.OPENED,
-        managers: [],
-        members: []
+        type: CommunityType.OPEN,
+        managers: []
       }
     ];
 
@@ -127,7 +126,7 @@ describe('CommunitiesService', () => {
 
     const request = httpTestingController.expectOne((req) =>
       req.method === 'GET'
-      && req.url === `${environment.serverApiUrl}/communities`
+      && req.url === `${environment.serverApiUrl}/users/e6b808eb-b6bd-447d-8dce-3e0d66b17759/community-recommendations`
     );
 
     expect(request.request.responseType).toEqual('json');
@@ -186,8 +185,7 @@ describe('CommunitiesService', () => {
       title: testCommunity.title,
       description: testCommunity.description,
       links: testCommunity.links,
-      managers: [],
-      members: []
+      managers: []
     } as CommunityResponse;
 
     service.updateCommunity(testCommunity).subscribe(community => {
@@ -226,8 +224,7 @@ describe('CommunitiesService', () => {
       title: testCommunityRequest.title,
       description: testCommunityRequest.description,
       links: testCommunityRequest.links,
-      managers: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}],
-      members: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}]
+      managers: [{id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'}]
     } as CommunityResponse;
 
     service.createCommunity(testCommunityRequest).subscribe(community => {
@@ -264,28 +261,20 @@ describe('CommunitiesService', () => {
 
     const communityId = 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f';
 
-    const testCommunityResponse: CommunityResponse = {
-      id: communityId,
-      title: 'test1',
-      description: 'description1',
-      links: [{
-        name: 'google',
-        href: 'https://www.google.com'
-      },
-        {
-          name: 'stackoveflow',
-          href: 'https://stackoverflow.com/'
-        }],
-      managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-      members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
-    } as CommunityResponse;
+    const testCommunityUserResponse: CommunityUserResponse = {
+      role: CommunityRole.MEMBER,
+      user: {
+        id: authenticatedUser.userId,
+        userName: authenticatedUser.userName
+      } as User
+    } as CommunityUserResponse;
 
     const communityUserRequest: CommunityUserRequest = {
       userId: authenticatedUser.userId
     } as CommunityUserRequest;
 
-    service.joinCommunity(communityId).subscribe((response: CommunityResponse) => {
-      expect(response).toEqual(testCommunityResponse);
+    service.joinCommunity(communityId).subscribe((response: CommunityUserResponse) => {
+      expect(response).toEqual(testCommunityUserResponse);
     });
 
     const req = httpTestingController.expectOne({
@@ -295,29 +284,13 @@ describe('CommunitiesService', () => {
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(communityUserRequest);
 
-    req.flush(testCommunityResponse);
+    req.flush(testCommunityUserResponse);
   }));
 
   it('should make user leave a community', async(() => {
     const communityId = 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f';
-    const testCommunityResponse: CommunityResponse = {
-      id: communityId,
-      title: 'test1',
-      description: 'description1',
-      links: [{
-        name: 'google',
-        href: 'https://www.google.com'
-      },
-        {
-          name: 'stackoveflow',
-          href: 'https://stackoverflow.com/'
-        }],
-      managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-      members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
-    } as CommunityResponse;
-
     service.leaveCommunity(communityId).subscribe((data: any) => {
-      expect(data).toEqual(testCommunityResponse);
+      expect(data).toBeUndefined();
     });
 
     const req = httpTestingController.expectOne({
@@ -325,31 +298,14 @@ describe('CommunitiesService', () => {
       url: `${environment.serverApiUrl}/communities/${communityId}/users/${authenticatedUser.userId}`
     });
     expect(req.request.method).toBe('DELETE');
-
-    req.flush(testCommunityResponse);
   }));
 
   it('should kick out a community member', async(() => {
     const communityId = 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f';
     const memberId = 'e6b808eb-b6bd-447d-8dce-3e0d66b17666';
-    const testCommunityResponse: CommunityResponse = {
-      id: communityId,
-      title: 'test1',
-      description: 'description1',
-      links: [{
-        name: 'google',
-        href: 'https://www.google.com'
-      },
-        {
-          name: 'stackoveflow',
-          href: 'https://stackoverflow.com/'
-        }],
-      managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-      members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
-    } as CommunityResponse;
 
     service.removeMember(communityId, memberId).subscribe((data: any) => {
-      expect(data).toEqual(testCommunityResponse);
+      expect(data).toBeUndefined();
     });
 
     const req = httpTestingController.expectOne({
@@ -357,8 +313,6 @@ describe('CommunitiesService', () => {
       url: `${environment.serverApiUrl}/communities/${communityId}/users/${memberId}`
     });
     expect(req.request.method).toBe('DELETE');
-
-    req.flush(testCommunityResponse);
   }));
 
 });

--- a/src/app/communities/communities.service.spec.ts
+++ b/src/app/communities/communities.service.spec.ts
@@ -126,7 +126,7 @@ describe('CommunitiesService', () => {
 
     const request = httpTestingController.expectOne((req) =>
       req.method === 'GET'
-      && req.url === `${environment.serverApiUrl}/users/e6b808eb-b6bd-447d-8dce-3e0d66b17759/community-recommendations`
+      && req.url === `${environment.serverApiUrl}/users/${authenticatedUser.userId}/community-recommendations`
     );
 
     expect(request.request.responseType).toEqual('json');

--- a/src/app/communities/communities.service.ts
+++ b/src/app/communities/communities.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { CommunityRequest } from './community-request';
@@ -7,6 +7,8 @@ import { CommunityResponse } from './community-response';
 import { UserIdentityService } from '../shared/user-identity.service';
 import { switchMap } from 'rxjs/operators';
 import { CommunityUserRequest } from './community-user-request';
+import { CommunityUserResponse } from './community-user-response';
+import { CommunityRole } from './community-role.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -17,6 +19,8 @@ export class CommunitiesService {
   private communityUrlPattern = `${environment.serverApiUrl}/communities/{communityId}`;
   private joinCommunityUrlPattern = `${environment.serverApiUrl}/communities/{communityId}/users`;
   private leaveCommunityUrlPattern = `${environment.serverApiUrl}/communities/{communityId}/users/{userId}`;
+  private userCommunitiesUrlPattern = `${environment.serverApiUrl}/users/{userId}/communities`;
+  private recommendedCommunitiesUrlPattern = `${environment.serverApiUrl}/users/{userId}/community-recommendations`;
 
   constructor(private httpClient: HttpClient,
               private userIdentityService: UserIdentityService) {
@@ -29,12 +33,21 @@ export class CommunitiesService {
   getRecommendedCommunities(): Observable<CommunityResponse[]> {
     return this.userIdentityService.getUserIdentity()
       .pipe(switchMap(userIdentity =>
-        // todo: /users/{userId}/community-recommendations
-        this.httpClient.get<CommunityResponse[]>(this.communitiesUrlPattern)));
+        this.httpClient.get<CommunityResponse[]>(this.recommendedCommunitiesUrlPattern.replace('{userId}', userIdentity.userId))));
   }
 
   getCommunity(communityId: string): Observable<CommunityResponse> {
     return this.httpClient.get<CommunityResponse>(this.communityUrlPattern.replace('{communityId}', communityId));
+  }
+
+  getCommunityUsers(communityId: string, role: CommunityRole): Observable<CommunityUserResponse[]> {
+    const params: HttpParams = new HttpParams();
+    if (role) {
+      params.append('role', role);
+    }
+    return this.httpClient.get<CommunityUserResponse[]>(this.joinCommunityUrlPattern.replace('{communityId}', communityId), {
+      params: params
+    });
   }
 
   createCommunity(data: CommunityRequest): Observable<CommunityResponse> {
@@ -49,22 +62,28 @@ export class CommunitiesService {
     return this.httpClient.delete<void>(this.communityUrlPattern.replace('{communityId}', communityId));
   }
 
-  joinCommunity(communityId: string): Observable<CommunityResponse> {
+  getUserCommunities(): Observable<CommunityResponse[]> {
     return this.userIdentityService.getUserIdentity()
       .pipe(switchMap(userIdentity =>
-        this.httpClient.post<CommunityResponse>(
+          this.httpClient.get<CommunityResponse[]>(this.userCommunitiesUrlPattern.replace('{userId}', userIdentity.userId))));
+  }
+
+  joinCommunity(communityId: string): Observable<CommunityUserResponse> {
+    return this.userIdentityService.getUserIdentity()
+      .pipe(switchMap(userIdentity =>
+        this.httpClient.post<CommunityUserResponse>(
           this.joinCommunityUrlPattern.replace('{communityId}', communityId), { userId: userIdentity.userId } as CommunityUserRequest)));
   }
 
-  leaveCommunity(communityId: string): Observable<CommunityResponse> {
+  leaveCommunity(communityId: string): Observable<void> {
     return this.userIdentityService.getUserIdentity()
       .pipe(switchMap(userIdentity =>
-        this.httpClient.delete<CommunityResponse>(
+        this.httpClient.delete<void>(
           this.leaveCommunityUrlPattern.replace('{communityId}', communityId).replace('{userId}', userIdentity.userId))));
   }
 
-  removeMember(communityId: string, userId: string): Observable<CommunityResponse> {
-    return this.httpClient.delete<CommunityResponse>(
+  removeMember(communityId: string, userId: string): Observable<void> {
+    return this.httpClient.delete<void>(
           this.leaveCommunityUrlPattern.replace('{communityId}', communityId).replace('{userId}', userId));
   }
 

--- a/src/app/communities/community-response.ts
+++ b/src/app/communities/community-response.ts
@@ -5,6 +5,5 @@ import { User } from '../users/user';
 export interface CommunityResponse extends Community {
   skills?: Skill[];
   managers: User[];
-  members: User[];
   recommended?: boolean;
 }

--- a/src/app/communities/community-role.enum.ts
+++ b/src/app/communities/community-role.enum.ts
@@ -1,0 +1,4 @@
+export enum CommunityRole {
+  MANAGER = 'MANAGER',
+  MEMBER = 'MEMBER'
+}

--- a/src/app/communities/community-type.enum.ts
+++ b/src/app/communities/community-type.enum.ts
@@ -1,4 +1,4 @@
 export enum CommunityType {
-  OPENED = 'OPENED',
+  OPEN = 'OPEN',
   CLOSED = 'CLOSED'
 }

--- a/src/app/communities/community-user-response.ts
+++ b/src/app/communities/community-user-response.ts
@@ -1,0 +1,7 @@
+import { User } from '../users/user';
+import { CommunityRole } from './community-role.enum';
+
+export class CommunityUserResponse {
+  user: User;
+  role: CommunityRole;
+}

--- a/src/app/community-view/community-view.component.html
+++ b/src/app/community-view/community-view.component.html
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div class="community-column-members">
-      <div class="community-toolbar" *ngIf="!isCommunityMember">
+      <div class="community-toolbar" *ngIf="isCommunityMember === false">
         <button mat-raised-button color="primary" (click)="joinCommunity()" aria-label="Join">Join</button>
       </div>
       <div class="community-toolbar" *ngIf="canLeaveCommunity()">
@@ -33,13 +33,16 @@
           <mat-chip *ngFor="let manager of community?.managers">{{ manager.firstName }} {{manager.lastName}}</mat-chip>
         </mat-chip-list>
       </div>
-      <div *ngIf="isCommunityMember">
+      <div *ngIf="isCommunityMember || isCommunityManager">
         <div class="community-label">Members</div>
         <mat-chip-list class="mat-chip-list-stacked" aria-orientation="vertical">
-          <mat-chip *ngFor="let user of community?.members" (removed)="removeMember(user)">{{ user.firstName }} {{user.lastName}}
-            <mat-icon matChipRemove *ngIf="canRemoveMember(user)" class="community-remove-member">cancel</mat-icon>
+          <mat-chip *ngFor="let cu of communityMembers" (removed)="removeMember(cu.user)">{{ cu.user.firstName }} {{cu.user.lastName}}
+            <mat-icon matChipRemove *ngIf="canRemoveMember(cu.user)" class="community-remove-member">cancel</mat-icon>
           </mat-chip>
         </mat-chip-list>
+      </div>
+      <div *ngIf="!isCommunityMember && !isCommunityManager" class="members-not-available-label">
+        Members are only visible to community members.
       </div>
     </div>
   </div>

--- a/src/app/community-view/community-view.component.scss
+++ b/src/app/community-view/community-view.component.scss
@@ -33,3 +33,8 @@
   position: absolute;
   right: 10px;
 }
+
+.members-not-available-label {
+  @extend %base-description-label;
+  margin-top: 15px;
+}

--- a/src/app/community-view/community-view.component.spec.ts
+++ b/src/app/community-view/community-view.component.spec.ts
@@ -18,6 +18,8 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 import { DeleteConfirmationDialogComponent } from '../shared/delete-confirmation-dialog/delete-confirmation-dialog.component';
 import { MatDialog } from '@angular/material';
 import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
+import { CommunityUserResponse } from '../communities/community-user-response';
+import { CommunityRole } from '../communities/community-role.enum';
 
 const authenticatedUser: UserIdentity = {
   userId: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759',
@@ -39,7 +41,7 @@ const community: CommunityResponse = {
   id: '123',
   title: 'group1',
   description: 'super group description',
-  type: CommunityType.OPENED,
+  type: CommunityType.OPEN,
   links: [
     {
       name: 'google',
@@ -49,13 +51,6 @@ const community: CommunityResponse = {
       name: 'stackoveflow',
       href: 'https://stackoverflow.com/'
     }],
-  members: [
-    {
-      id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666',
-      userName: 'tester'
-    } as User,
-    userForKicking
-  ],
   managers: [
     {
       id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666',
@@ -81,6 +76,20 @@ describe('CommunityViewComponent', () => {
       providers: [
         {
           provide: CommunitiesService, useValue: jasmine.createSpyObj('communityService', {
+            'getUserCommunities': of<CommunityResponse[]>(),
+            'getCommunityUsers': of<CommunityUserResponse[]>([
+              {
+                user: {
+                  id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666',
+                  userName: 'tester'
+                } as User,
+                role: CommunityRole.MEMBER
+              } as CommunityUserResponse,
+              {
+                user: userForKicking,
+                role: CommunityRole.MEMBER
+              } as CommunityUserResponse
+            ]),
             'getCommunity': of(community),
             'leaveCommunity': of<CommunityResponse>({
               id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
@@ -94,14 +103,13 @@ describe('CommunityViewComponent', () => {
                   name: 'stackoveflow',
                   href: 'https://stackoverflow.com/'
                 }],
-              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}],
-              members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}]
+              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}]
             } as CommunityResponse),
             'joinCommunity': of<CommunityResponse>({
               id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
               title: 'test1',
               description: 'description1',
-              type: CommunityType.OPENED,
+              type: CommunityType.OPEN,
               links: [{
                 name: 'google',
                 href: 'https://www.google.com'
@@ -110,8 +118,7 @@ describe('CommunityViewComponent', () => {
                   name: 'stackoveflow',
                   href: 'https://stackoverflow.com/'
                 }],
-              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}],
-              members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}]
+              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}]
             } as CommunityResponse),
             'removeMember': of<CommunityResponse>({
               id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
@@ -125,8 +132,7 @@ describe('CommunityViewComponent', () => {
                   name: 'stackoveflow',
                   href: 'https://stackoverflow.com/'
                 }],
-              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}],
-              members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}]
+              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666'}]
             } as CommunityResponse)
           })
         },
@@ -192,24 +198,18 @@ describe('CommunityViewComponent', () => {
   }));
 
   it('should not make user join a closed community and display closed community info dialog', fakeAsync(() => {
-    const closedCommunity = {
-      id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
-      title: 'test1',
-      type: CommunityType.CLOSED,
-      description: 'description1',
-      links: [{
-        name: 'google',
-        href: 'https://www.google.com'
-      },
-        {
-          name: 'stackoveflow',
-          href: 'https://stackoverflow.com/'
-        }],
-      managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-      members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
-    };
+    const communityUserResponse = {
+      role: CommunityRole.MEMBER,
+      user: {
+        id: authenticatedUser.userId,
+        userName: authenticatedUser.userName
+      } as User
+    } as CommunityUserResponse;
+    const c: CommunityResponse = Object.assign({}, component.community);
+    c.type = CommunityType.CLOSED;
+    component.community = c;
     const communityService = TestBed.get(CommunitiesService) as CommunitiesService;
-    communityService.joinCommunity = jasmine.createSpy().and.returnValue(of(closedCommunity));
+    communityService.joinCommunity = jasmine.createSpy().and.returnValue(of(communityUserResponse));
 
     component.joinCommunity();
     fixture.detectChanges();

--- a/src/app/community-view/community-view.component.spec.ts
+++ b/src/app/community-view/community-view.component.spec.ts
@@ -76,20 +76,20 @@ describe('CommunityViewComponent', () => {
       providers: [
         {
           provide: CommunitiesService, useValue: jasmine.createSpyObj('communityService', {
-            'getUserCommunities': of<CommunityResponse[]>(),
-            'getCommunityUsers': of<CommunityUserResponse[]>([
-              {
-                user: {
-                  id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17666',
-                  userName: 'tester'
-                } as User,
-                role: CommunityRole.MEMBER
-              } as CommunityUserResponse,
-              {
-                user: userForKicking,
-                role: CommunityRole.MEMBER
-              } as CommunityUserResponse
-            ]),
+            'getUserCommunities': of<CommunityResponse[]>(
+              [
+                {
+                  id: '123',
+                  title: 'Java User Group',
+                  type: CommunityType.OPEN
+                } as CommunityResponse,
+                {
+                  id: '456',
+                  title: 'Scala User Group'
+                } as CommunityResponse
+              ]
+            ),
+            'getCommunityUsers': of<CommunityUserResponse[]>(),
             'getCommunity': of(community),
             'leaveCommunity': of<CommunityResponse>({
               id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',

--- a/src/app/community-view/community-view.component.spec.ts
+++ b/src/app/community-view/community-view.component.spec.ts
@@ -201,18 +201,8 @@ describe('CommunityViewComponent', () => {
   it('should make user leave a community', fakeAsync(() => {
     expect(component.canLeaveCommunity).toBeTruthy();
     component.leaveCommunity();
-    tick();
-    fakeAsync(() => {
-      const matDialog: MatDialog = TestBed.get(MatDialog);
-      expect(matDialog.openDialogs.length).toBe(1);
-      expect(matDialog.openDialogs[0].componentInstance).toEqual(jasmine.any(DeleteConfirmationDialogComponent));
-      matDialog.openDialogs[0].close(true);
-      tick();
-      fakeAsync(() => {
-        tick();
-        expect(component.isCommunityMember).toBeFalsy();
-      });
-    });
+    fixture.detectChanges();
+    expect(component.isCommunityMember).toBeFalsy();
   }));
 
   it('should not make user join a closed community and display closed community info dialog', fakeAsync(() => {
@@ -230,7 +220,7 @@ describe('CommunityViewComponent', () => {
     communityService.joinCommunity = jasmine.createSpy().and.returnValue(of(communityUserResponse));
 
     component.joinCommunity();
-    tick();
+    fixture.detectChanges();
     expect(component.isCommunityMember).toBeFalsy();
 
     const matDialog: MatDialog = TestBed.get(MatDialog);

--- a/src/app/community-view/community-view.component.ts
+++ b/src/app/community-view/community-view.component.ts
@@ -11,6 +11,8 @@ import { MatDialog } from '@angular/material';
 import { User } from '../users/user';
 import { CommunityType } from '../communities/community-type.enum';
 import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
+import { CommunityUserResponse } from '../communities/community-user-response';
+import { CommunityRole } from '../communities/community-role.enum';
 
 @Component({
   selector: 'app-community-view',
@@ -22,6 +24,8 @@ export class CommunityViewComponent implements OnInit {
   private currentUserId: string;
 
   community: CommunityResponse;
+  communityMembers: CommunityUserResponse[] = [];
+  communityManagers: CommunityUserResponse[] = [];
   errorMessage: string = null;
   isCommunityMember: boolean;
   isCommunityManager: boolean;
@@ -39,16 +43,16 @@ export class CommunityViewComponent implements OnInit {
       .pipe(map(params => params.get('communityId')))
       .subscribe(communityId => {
         this.loadCommunity(communityId);
+        this.loadCommunityUsers(communityId);
       });
   }
 
   joinCommunity() {
-    this.communityService.joinCommunity(this.community.id).subscribe((community: CommunityResponse) => {
-      if (community.type === CommunityType.CLOSED) {
-        this.showInfoDialog(community);
+    this.communityService.joinCommunity(this.community.id).subscribe((communityUserResponse: CommunityUserResponse) => {
+      if (this.community.type === CommunityType.CLOSED) {
+        this.showInfoDialog(this.community);
       } else {
         this.isCommunityMember = true;
-        this.community = community;
       }
     }, (errorResponse: HttpErrorResponse) => {
       this.handleErrorResponse(errorResponse);
@@ -64,9 +68,8 @@ export class CommunityViewComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        this.communityService.leaveCommunity(this.community.id).subscribe((community: CommunityResponse) => {
+        this.communityService.leaveCommunity(this.community.id).subscribe(() => {
           this.isCommunityMember = false;
-          this.community = community;
         }, (errorResponse: HttpErrorResponse) => {
           this.handleErrorResponse(errorResponse);
         });
@@ -75,11 +78,10 @@ export class CommunityViewComponent implements OnInit {
   }
 
   /**
-   * User can leave a community when he/she is not the only member or is not the only manager
+   * User can leave a community when he/she is a member of a community and is not a community manager.
    */
   canLeaveCommunity() {
-    return !this.isCommunityManager && this.isCommunityMember && this.community.members && this.community.members.length > 1
-      || this.isCommunityManager && this.community.managers && this.community.managers.length > 1;
+    return !this.isCommunityManager && this.isCommunityMember;
   }
 
   canRemoveMember(user: User) {
@@ -95,9 +97,7 @@ export class CommunityViewComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        this.communityService.removeMember(this.community.id, member.id).subscribe((community: CommunityResponse) => {
-          this.community = community;
-        }, (errorResponse: HttpErrorResponse) => {
+        this.communityService.removeMember(this.community.id, member.id).subscribe(() => {}, (errorResponse: HttpErrorResponse) => {
           this.handleErrorResponse(errorResponse);
         });
       }
@@ -108,17 +108,34 @@ export class CommunityViewComponent implements OnInit {
     this.communityService.getCommunity(communityId)
       .subscribe(community => {
         this.community = community;
-        this.detectMembership(community);
       }, errorResponse => {
         this.handleErrorResponse(errorResponse);
       });
   }
 
-  private detectMembership(community: CommunityResponse) {
+  private loadCommunityUsers(communityId: string) {
+    this.communityService.getCommunityUsers(communityId, null).subscribe((communityUsers: CommunityUserResponse[]) => {
+      this.detectMembership(communityUsers);
+    }, (errorResponse: HttpErrorResponse) => {
+      if (errorResponse.status !== 403) {
+        this.handleErrorResponse(errorResponse);
+      } else {
+        this.isCommunityMember = false;
+        this.isCommunityManager = false;
+      }
+    });
+  }
+
+  private detectMembership(communityUsers: CommunityUserResponse[]) {
+    if (!communityUsers) {
+      return;
+    }
     this.userIdentityService.getUserIdentity().subscribe(userIdentity => {
       this.currentUserId = userIdentity.userId;
-      this.isCommunityMember = community.members && community.members.find(item => item.id === userIdentity.userId) != null;
-      this.isCommunityManager = community.managers && community.managers.find(item => item.id === userIdentity.userId) != null;
+      this.communityMembers = communityUsers.filter(cm => cm.role as CommunityRole === CommunityRole.MEMBER);
+      this.communityManagers = communityUsers.filter(cm => cm.role as CommunityRole === CommunityRole.MANAGER);
+      this.isCommunityMember = this.communityMembers && this.communityMembers.find(item => item.user.id === userIdentity.userId) != null;
+      this.isCommunityManager = this.communityManagers && this.communityManagers.find(item => item.user.id === userIdentity.userId) != null;
     }, errorResponse => {
       this.handleErrorResponse(errorResponse);
     });

--- a/src/app/community-view/community-view.component.ts
+++ b/src/app/community-view/community-view.component.ts
@@ -132,8 +132,8 @@ export class CommunityViewComponent implements OnInit {
     }
     this.userIdentityService.getUserIdentity().subscribe(userIdentity => {
       this.currentUserId = userIdentity.userId;
-      this.communityMembers = communityUsers.filter(cm => cm.role as CommunityRole === CommunityRole.MEMBER);
-      this.communityManagers = communityUsers.filter(cm => cm.role as CommunityRole === CommunityRole.MANAGER);
+      this.communityMembers = communityUsers.filter(cm => cm.role === CommunityRole.MEMBER);
+      this.communityManagers = communityUsers.filter(cm => cm.role === CommunityRole.MANAGER);
       this.isCommunityMember = this.communityMembers && this.communityMembers.find(item => item.user.id === userIdentity.userId) != null;
       this.isCommunityManager = this.communityManagers && this.communityManagers.find(item => item.user.id === userIdentity.userId) != null;
     }, errorResponse => {

--- a/src/app/community-view/community-view.component.ts
+++ b/src/app/community-view/community-view.component.ts
@@ -134,8 +134,8 @@ export class CommunityViewComponent implements OnInit {
       this.currentUserId = userIdentity.userId;
       this.communityMembers = communityUsers.filter(cm => cm.role === CommunityRole.MEMBER);
       this.communityManagers = communityUsers.filter(cm => cm.role === CommunityRole.MANAGER);
-      this.isCommunityMember = this.communityMembers && this.communityMembers.find(item => item.user.id === userIdentity.userId) != null;
-      this.isCommunityManager = this.communityManagers && this.communityManagers.find(item => item.user.id === userIdentity.userId) != null;
+      this.isCommunityMember = this.communityMembers && this.communityMembers.some(item => item.user.id === userIdentity.userId);
+      this.isCommunityManager = this.communityManagers && this.communityManagers.some(item => item.user.id === userIdentity.userId);
     }, errorResponse => {
       this.handleErrorResponse(errorResponse);
     });

--- a/src/app/projects/projects-new.component.ts
+++ b/src/app/projects/projects-new.component.ts
@@ -46,7 +46,6 @@ export class ProjectsNewComponent implements OnInit, OnDestroy {
     this.projectService.createProject(this.getProjectData())
       .pipe(
         finalize( () => {
-            console.log('asdasd')
             this.savingInProgress = false;
           }
         )

--- a/src/app/recommended-communities/recommended-communities.component.html
+++ b/src/app/recommended-communities/recommended-communities.component.html
@@ -1,4 +1,4 @@
-<div class="recommended-communities">
+<div *ngIf="(communities$ | async)?.length" class="recommended-communities">
   <div *ngIf="errorMessage" class="recommended-communities-error-message">{{errorMessage}}</div>
   <h2>Recommended communities</h2>
   <div class="recommended-communities-wrapper">

--- a/src/app/recommended-communities/recommended-communities.component.spec.ts
+++ b/src/app/recommended-communities/recommended-communities.component.spec.ts
@@ -17,13 +17,15 @@ import { GlobalErrorHandlerService } from '../error/global-error-handler.service
 import { MatDialog } from '@angular/material';
 import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { CommunityUserResponse } from '../communities/community-user-response';
+import { CommunityRole } from '../communities/community-role.enum';
 
 const communities: CommunityResponse[] = [
   {
     id: '123',
     title: 'group1',
     description: 'super group description',
-    type: CommunityType.OPENED,
+    type: CommunityType.OPEN,
     recommended: true,
     links: [
       {
@@ -34,37 +36,25 @@ const communities: CommunityResponse[] = [
         name: 'stackoveflow',
         href: 'https://stackoverflow.com/'
       }],
-    members: [
-      {
-        id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759',
-        userName: 'tester'
-      } as User
-    ],
     managers: [
       {
         id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759',
         userName: 'tester'
       } as User
     ]
-  },
+  } as CommunityResponse,
   {
     id: '123456',
     title: 'group2',
     description: 'other group',
-    type: CommunityType.OPENED,
-    members: [
-      {
-        id: 'c6d8badc-0f80-4d20-b436-0e7e871f97f5',
-        userName: 'anotherTester'
-      } as User
-    ],
+    type: CommunityType.OPEN,
     managers: [
       {
         id: 'c6d8badc-0f80-4d20-b436-0e7e871f97f5',
         userName: 'anotherTester'
       } as User
     ]
-  }
+  } as CommunityResponse
 ];
 
 describe('RecommendedCommunitiesComponent', () => {
@@ -88,7 +78,7 @@ describe('RecommendedCommunitiesComponent', () => {
             'joinCommunity': of<CommunityResponse>({
               id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
               title: 'test1',
-              type: CommunityType.OPENED,
+              type: CommunityType.OPEN,
               description: 'description1',
               links: [{
                 name: 'google',
@@ -98,8 +88,7 @@ describe('RecommendedCommunitiesComponent', () => {
                   name: 'stackoveflow',
                   href: 'https://stackoverflow.com/'
                 }],
-              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-              members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
+              managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
             } as CommunityResponse)
           })
         },
@@ -126,26 +115,17 @@ describe('RecommendedCommunitiesComponent', () => {
 
 
   it('should display closed community info dialog', fakeAsync(() => {
-    const closedCommunity = {
-      id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
-      title: 'test1',
-      type: CommunityType.CLOSED,
-      description: 'description1',
-      links: [{
-        name: 'google',
-        href: 'https://www.google.com'
-      },
-        {
-          name: 'stackoveflow',
-          href: 'https://stackoverflow.com/'
-        }],
-      managers: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}],
-      members: [{id: 'e6b808eb-b6bd-447d-8dce-3e0d66b17759'}]
-    };
+    const communityUserResponse = {
+      role: CommunityRole.MEMBER,
+      user: {
+        id: '123',
+        userName: 'tester'
+      } as User
+    } as CommunityUserResponse;
     const communityService = TestBed.get(CommunitiesService) as CommunitiesService;
-    communityService.joinCommunity = jasmine.createSpy().and.returnValue(of(closedCommunity));
+    communityService.joinCommunity = jasmine.createSpy().and.returnValue(of(communityUserResponse));
 
-    component.joinCommunity({id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f'} as CommunityResponse);
+    component.joinCommunity({id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f', type: CommunityType.CLOSED} as CommunityResponse);
     fixture.detectChanges();
 
     const matDialog: MatDialog = TestBed.get(MatDialog);

--- a/src/app/recommended-communities/recommended-communities.component.ts
+++ b/src/app/recommended-communities/recommended-communities.component.ts
@@ -7,6 +7,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ClosedCommunityInfoDialogComponent } from '../shared/closed-community-info-dialog/closed-community-info-dialog.component';
 import { MatDialog } from '@angular/material';
 import { GlobalErrorHandlerService } from '../error/global-error-handler.service';
+import { CommunityUserResponse } from '../communities/community-user-response';
 
 @Component({
   selector: 'app-recommended-communities',
@@ -29,7 +30,7 @@ export class RecommendedCommunitiesComponent implements OnInit {
   }
 
   joinCommunity(community: CommunityResponse) {
-    this.communityService.joinCommunity(community.id).subscribe((community: CommunityResponse) => {
+    this.communityService.joinCommunity(community.id).subscribe((communityUserResponse: CommunityUserResponse) => {
       if (community.type === CommunityType.CLOSED) {
         this.showInfoDialog(community);
       }

--- a/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.spec.ts
+++ b/src/app/shared/closed-community-info-dialog/closed-community-info-dialog.component.spec.ts
@@ -8,7 +8,7 @@ const communityData = {
   id: '2134-5679-235235',
   title: 'community',
   description: 'community description',
-  type: CommunityType.OPENED,
+  type: CommunityType.OPEN,
   skills: [],
   links: [
     {

--- a/src/app/shared/community-card/community-card.component.spec.ts
+++ b/src/app/shared/community-card/community-card.component.spec.ts
@@ -13,7 +13,7 @@ import { By } from '@angular/platform-browser';
 const community = {
   id: 'd11235de-f13e-4fd6-b5d6-9c4c4e18aa4f',
   title: 'test1',
-  type: CommunityType.OPENED,
+  type: CommunityType.OPEN,
   description: 'description1',
   links: [{
     name: 'google',


### PR DESCRIPTION
OPENED community type renamed to OPEN.
Reworked community API is used to interact with the server.
'members' field removed from CommunityResponse.
Tests adjusted.

@svetivanova could you please take a look?